### PR TITLE
fix: minor fixes

### DIFF
--- a/claude.py
+++ b/claude.py
@@ -72,13 +72,13 @@ def claude(model, temperature, max_tokens, infile, outfile, prompt):
         fullprompt = prompt.strip()
 
     try:
-    client = anthropic.Anthropic()
-    message = client.messages.create(
-        model=model_fullname,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        messages=[{"role": "user", "content": fullprompt}],
-    )
+        client = anthropic.Anthropic()
+        message = client.messages.create(
+            model=model_fullname,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            messages=[{"role": "user", "content": fullprompt}],
+        )
     except anthropic.BadRequestError as ex:
         print(ex.body["error"]["message"])
         exit(1)

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     # This utility helps us iterate through each of our supported systems
     flake-utils.lib.eachDefaultSystem(system:
       let
-        
+
         # Let's grab Python 3.12 from Nixpkgs 
         pkgs = nixpkgs.legacyPackages.${system};
         python = pkgs.python312;
@@ -25,15 +25,12 @@
           anthropic
         ]);
 
-        # Grblock m'jabber icbog jerslahmpe. I copied this. No idea.
-        outputName = builtins.attrNames self.outputs self.outputs;
-
         # Use the simplest builder, mkDerivation, to create our output
         # (and call it 'claude'
         claude = with pkgs; stdenv.mkDerivation {
 
           # These are important and we all know why
-          name = "claude-cli";
+          pname = "claude";
           version = "0.0.1";
 
           # Make sure we bring those Python packages we defined above
@@ -51,16 +48,12 @@
 
         # Dev shells need our Python packages too
         devShells.default = pkgs.mkShell {
-          buildInputs = [ python_packages ];
+          inputsFrom = [ claude ];
         };
 
         # The main thing inside this flake is the output we called
         # 'claude' and if the flake is run this will be what is run
         packages.default = claude;
-
-        # This comment is proof that I did not write this flake by myself
-        # b/c this line means nothing to me
-        apps.default = flake-utils.lib.mkApp {drv = claude;};
       }
   );
 }


### PR DESCRIPTION
- python whitespace fixes for try-catch
- use pname to allow version to be used
- name the script the same as the attrPath to allow "nix run"
- no need for "outputName" 
- app is not needed as "nix run" will use the default package!

### Answers
- Perhaps this means that our source isn't an archive that needs to be extracted?
  - Yes. Another approach would be to set `src = ./.;`
- `buildInputs` vs. `inputsFrom`: using inputsFrom means if we add more to claude, the devShell gets it for free